### PR TITLE
Add customizable theme colors

### DIFF
--- a/apps/mail/app/(routes)/settings/appearance/page.tsx
+++ b/apps/mail/app/(routes)/settings/appearance/page.tsx
@@ -30,6 +30,8 @@ import * as z from 'zod';
 
 const formSchema = z.object({
   colorTheme: z.enum(['dark', 'light', 'system', '']),
+  accentColor: z.string().default('#437DFB'),
+  backgroundColor: z.string().default('#FFFFFF'),
 });
 
 type Theme = 'dark' | 'light' | 'system';
@@ -46,6 +48,8 @@ export default function AppearancePage() {
     resolver: zodResolver(formSchema),
     defaultValues: {
       colorTheme: data?.settings.colorTheme || (theme as Theme),
+      accentColor: data?.settings.accentColor || '#437DFB',
+      backgroundColor: data?.settings.backgroundColor || '#FFFFFF',
     },
   });
 
@@ -77,6 +81,8 @@ export default function AppearancePage() {
         saveUserSettings({
           ...data.settings,
           colorTheme: values.colorTheme as Theme,
+          accentColor: values.accentColor,
+          backgroundColor: values.backgroundColor,
         }),
         {
           success: t('common.settings.saved'),
@@ -158,6 +164,32 @@ export default function AppearancePage() {
                     )}
                   />
                 ) : null}
+                <FormField
+                  control={form.control}
+                  name="accentColor"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('pages.settings.appearance.accentColor')}</FormLabel>
+                      <FormControl>
+                        <input type="color" className="h-8 w-16" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="backgroundColor"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('pages.settings.appearance.backgroundColor')}</FormLabel>
+                      <FormControl>
+                        <input type="color" className="h-8 w-16" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </div>
             </div>
           </form>

--- a/apps/mail/locales/en.json
+++ b/apps/mail/locales/en.json
@@ -414,6 +414,8 @@
         "title": "Appearance",
         "description": "Customize colors, fonts and view options.",
         "theme": "Theme",
+        "accentColor": "Accent Color",
+        "backgroundColor": "Background Color",
         "inboxType": "Inbox Type"
       },
       "signatures": {

--- a/apps/mail/providers/client-providers.tsx
+++ b/apps/mail/providers/client-providers.tsx
@@ -5,12 +5,27 @@ import { useSettings } from '@/hooks/use-settings';
 import CustomToaster from '@/components/ui/toast';
 import { Provider as JotaiProvider } from 'jotai';
 import type { PropsWithChildren } from 'react';
+import { useEffect } from 'react';
+import Color from 'color';
 import { ThemeProvider } from 'next-themes';
 
 export function ClientProviders({ children }: PropsWithChildren) {
   const { data } = useSettings();
 
   const theme = data?.settings.colorTheme || 'system';
+
+  useEffect(() => {
+    if (!data?.settings) return;
+    const { accentColor, backgroundColor } = data.settings;
+    if (accentColor) {
+      const [h, s, l] = Color(accentColor).hsl().array();
+      document.documentElement.style.setProperty('--accent', `${h} ${s}% ${l}%`);
+    }
+    if (backgroundColor) {
+      const [h, s, l] = Color(backgroundColor).hsl().array();
+      document.documentElement.style.setProperty('--background', `${h} ${s}% ${l}%`);
+    }
+  }, [data?.settings?.accentColor, data?.settings?.backgroundColor]);
 
   return (
     <NuqsAdapter>

--- a/apps/server/src/db/migrations/0029_flexible_theme_colors.sql
+++ b/apps/server/src/db/migrations/0029_flexible_theme_colors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mail0_user_settings" ALTER COLUMN "settings" SET DEFAULT '{"language":"en","timezone":"UTC","dynamicContent":false,"externalImages":true,"customPrompt":"","trustedSenders":[],"isOnboarded":false,"colorTheme":"system","accentColor":"#437DFB","backgroundColor":"#FFFFFF","zeroSignature":true}'::jsonb;

--- a/apps/server/src/lib/schemas.ts
+++ b/apps/server/src/lib/schemas.ts
@@ -43,6 +43,8 @@ export const defaultUserSettings = {
   trustedSenders: [],
   isOnboarded: false,
   colorTheme: 'system',
+  accentColor: '#437DFB',
+  backgroundColor: '#FFFFFF',
   zeroSignature: true,
 } satisfies UserSettings;
 
@@ -55,6 +57,8 @@ export const userSettingsSchema = z.object({
   isOnboarded: z.boolean().optional(),
   trustedSenders: z.string().array().optional(),
   colorTheme: z.enum(['light', 'dark', 'system']).default('system'),
+  accentColor: z.string().default('#437DFB'),
+  backgroundColor: z.string().default('#FFFFFF'),
   zeroSignature: z.boolean().default(true),
 });
 


### PR DESCRIPTION
## Summary
- allow users to select accent and background colors
- apply selected colors in the client provider
- save new settings fields in the DB schema
- add migration for new defaults
- update English locale strings

## Testing
- `pnpm run check` *(fails: Cannot find package 'prettier-plugin-sort-imports')*

------
https://chatgpt.com/codex/tasks/task_e_6844c239226c8321a98cee123d6ad71c